### PR TITLE
Implement login and signup pages

### DIFF
--- a/lib/fetch.ts
+++ b/lib/fetch.ts
@@ -1,0 +1,33 @@
+import { NextRouter } from 'next/router';
+
+export const getRequest = async (url: string, router: NextRouter) => {
+  const res = await fetch(url);
+  if (res.redirected) {
+    router.replace(res.url);
+    return {};
+  }
+  if (res.ok) {
+    return await res.json();
+  }
+  console.error(`Error al llamar a ${url}`);
+};
+
+export const postRequest = async (
+  url: string,
+  body: any,
+  router: NextRouter,
+) => {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (res.redirected) {
+    router.replace(res.url);
+    return {};
+  }
+  if (res.ok) {
+    return await res.json();
+  }
+  console.error(`Error al llamar a ${url}`, body);
+};

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "next": "^10.2.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "ts-node": "^9.1.1"
+    "ts-node": "^9.1.1",
+    "validator": "^13.6.0"
   },
   "license": "MIT",
   "private": false,
@@ -40,6 +41,7 @@
     "@types/mongoose": "^5.10.5",
     "@types/node": "^15.0.2",
     "@types/react": "^17.0.5",
+    "@types/validator": "^13.1.3",
     "typescript": "^4.2.4"
   }
 }

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -9,6 +9,7 @@ const DashboardPage: React.FC = () => {
   const router = useRouter();
 
   useEffect(() => {
+    // TODO: Borrar, es sólo ejemplo de getRequest
     getRequest('/api/auth/hello', router).then((res) => setUser(res.user));
   }, []);
   return (

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useState } from 'react';
+import Head from 'next/head';
+import { useRouter } from 'next/router';
+
+import { getRequest } from '../lib/fetch';
+
+const DashboardPage: React.FC = () => {
+  const [user, setUser] = useState('');
+  const router = useRouter();
+
+  useEffect(() => {
+    getRequest('/api/auth/hello', router).then((res) => setUser(res.user));
+  }, []);
+  return (
+    <>
+      <Head>
+        <title>Dashboard</title>
+      </Head>
+      <div className="container">
+        <main>
+          <h1 className="title">Dashboard</h1>
+          <p className="description">Usuario {user}</p>
+        </main>
+
+        <style jsx>{`
+          .container {
+            min-height: 100vh;
+            padding: 0 0.5rem;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+          }
+
+          main {
+            padding: 5rem 0;
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+          }
+
+          .title {
+            margin: 0;
+            line-height: 1.15;
+            font-size: 4rem;
+          }
+
+          .title,
+          .description {
+            text-align: center;
+          }
+
+          .description {
+            line-height: 1.5;
+            font-size: 1.5rem;
+          }
+        `}</style>
+      </div>
+    </>
+  );
+};
+
+export default DashboardPage;

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,72 +1,134 @@
 import React, { useState } from 'react';
-import { Button, Card, Input, Spacer } from '@geist-ui/react';
+import Head from 'next/head';
+import { useRouter } from 'next/router';
+import { Button, Card, Input, Row, Spacer, Text } from '@geist-ui/react';
+import isEmail from 'validator/lib/isEmail';
+import isLength from 'validator/lib/isLength';
+
+import { postRequest } from '../lib/fetch';
 
 const LoginPage: React.FC = () => {
-  const [username, setUsername] = useState('');
+  const [view, setView] = useState<'login' | 'register'>('login');
+  const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [errorMsg, setErrorMsg] = useState<string>('');
+  const router = useRouter();
+
+  const login = async () => {
+    if (view === 'register') {
+      if (!isEmail(email)) {
+        setErrorMsg('Ingrese un correo electrónico es válido');
+        return;
+      }
+      if (!isLength(password, { min: 6 })) {
+        setErrorMsg('La contraseña debe de ser de al menos 6 caracteres');
+        return;
+      }
+    }
+    const apiUrl = view === 'login' ? '/api/auth/login' : '/api/auth/signup';
+    const body = { email, password };
+    const resBody = await postRequest(apiUrl, body, router);
+    if (resBody.error) {
+      setErrorMsg(resBody.error);
+    }
+  };
+
   return (
-    <div className="container">
-      <Card shadow>
-        <Input
-          size="large"
-          value={username}
-          onChange={(e) => setUsername(e.target.value)}
-        >
-          Usuario
-        </Input>
-        <Spacer />
-        <Input
-          size="large"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-        >
-          Contraseña
-        </Input>
-        <Spacer />
-        <Button type="success-light" size="large">
-          Iniciar sesión
-        </Button>
-        <Spacer y={0.5} />
-        <Button type="success" ghost size="large">
-          Regístrate
-        </Button>
-      </Card>
-      <style jsx>{`
-        .container {
-          min-height: 100vh;
-          padding: 0 0.5rem;
-          display: flex;
-          flex-direction: column;
-          justify-content: center;
-          align-items: center;
-        }
-      `}</style>
+    <>
+      <Head>
+        <title>{view === 'login' ? 'Inicia sesión' : 'Regístrate'}</title>
+      </Head>
+      <div className="container">
+        <Card shadow>
+          <Row justify="space-around">
+            <Text
+              h3
+              type={view === 'login' ? 'success' : 'secondary'}
+              onClick={() => {
+                setView('login');
+                setErrorMsg('');
+              }}
+            >
+              Inicia sesión
+            </Text>
+            <Text
+              h3
+              type={view === 'register' ? 'success' : 'secondary'}
+              onClick={() => {
+                setView('register');
+                setErrorMsg('');
+              }}
+            >
+              Regístrate
+            </Text>
+          </Row>
+          <Spacer y={0.5} />
+          <Input
+            size="large"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          >
+            Correo electrónico
+          </Input>
+          <Spacer />
+          <Input
+            size="large"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          >
+            Contraseña
+          </Input>
+          <Spacer y={0.5} />
+          {errorMsg && (
+            <Text type="error" className="error-msg">
+              {errorMsg}
+            </Text>
+          )}
+          <Spacer y={0.5} />
+          <Button type="success-light" size="large" onClick={login}>
+            {view === 'login' ? 'Iniciar sesión' : 'Regístrate'}
+          </Button>
+          <Spacer y={0.5} />
+        </Card>
 
-      <style jsx global>{`
-        html,
-        body {
-          padding: 0;
-          margin: 0;
-          font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
-            Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue,
-            sans-serif;
-        }
+        <style jsx global>{`
+          .container {
+            min-height: 100vh;
+            padding: 0 0.5rem;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+          }
 
-        div.card {
-          width: auto !important;
-        }
+          div.card {
+            width: auto !important;
+          }
 
-        div.content {
-          display: flex;
-          flex-direction: column;
-          justify-content: center;
-        }
+          div.content {
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+          }
 
-        * {
-          box-sizing: border-box;
-        }
-      `}</style>
-    </div>
+          h3 {
+            font-weight: 400;
+            cursor: pointer;
+          }
+
+          p.error-msg {
+            margin: 0 auto;
+            max-width: 220px;
+            text-align: center;
+          }
+
+          * {
+            box-sizing: border-box;
+          }
+        `}</style>
+      </div>
+    </>
   );
 };
 

--- a/server/middleware/isAuthenticated.ts
+++ b/server/middleware/isAuthenticated.ts
@@ -1,0 +1,10 @@
+import { NextFunction, Request, Response } from 'express';
+
+const isAuthenticated = (req: Request, res: Response, next: NextFunction) => {
+  if (req.session.user) {
+    return next();
+  }
+  res.redirect('/login');
+};
+
+export default isAuthenticated;

--- a/server/routers/auth.ts
+++ b/server/routers/auth.ts
@@ -60,6 +60,7 @@ router.get('/logout', async (req: Request, res: Response) => {
   res.redirect('/login');
 });
 
+// TODO: Borrar, es sólo ejemplo de isAuthenticated
 router.get('/hello', isAuthenticated, async (req: Request, res: Response) => {
   res.send({ user: req.session.user });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -243,6 +243,11 @@
     "@types/mime" "^1"
     "@types/node" "*"
 
+"@types/validator@^13.1.3":
+  version "13.1.3"
+  resolved "https://registry.yarnpkg.com/@types/validator/-/validator-13.1.3.tgz#366b394aa3fbeed2392bf0a20ded606fa4a3d35e"
+  integrity sha512-DaOWN1zf7j+8nHhqXhIgNmS+ltAC53NXqGxYuBhWqWgqolRhddKzfZU814lkHQSTG0IUfQxU7Cg0gb8fFWo2mA==
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -2826,7 +2831,7 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-validator@^13.5.2:
+validator@^13.5.2, validator@^13.6.0:
   version "13.6.0"
   resolved "https://registry.yarnpkg.com/validator/-/validator-13.6.0.tgz#1e71899c14cdc7b2068463cb24c1cc16f6ec7059"
   integrity sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg==


### PR DESCRIPTION
Closes #3 and #4 

Ya implementé la funcionalidad de iniciar sesión y de registrarse en la misma página, '/login'

Añadí dos métodos para hacer fetch al api y en el caso de que el usuario no esté autenticado lo regrese a /login, son los que están en lib/fetch.ts. Un ejemplo está en pages/dashboard.tsx, línea 13

También hice un middleware para que redireccione las llamadas no autenticadas en el server, un ejemplo está en server/routers/auth.ts, línea 64