### PR TITLE
Stats router and sample data

### DIFF
--- a/server/main.ts
+++ b/server/main.ts
@@ -17,6 +17,7 @@ const port = parseInt(process.env.PORT || '', 10) || 3000;
 
 import authRouter from './routers/auth';
 import transRouter from './routers/transactions';
+import statsRouter from './routers/stats';
 // TODO: Delete import
 import { createSampleData } from './sampleData';
 
@@ -63,6 +64,9 @@ const handle = app.getRequestHandler();
 
   // Transactions router
   server.use('/api/trans', transRouter);
+
+  // Transactions router
+  server.use('/api/stats', statsRouter);
 
   // Handle routes with next.js
   server.all('*', (req, res) => handle(req, res));

--- a/server/main.ts
+++ b/server/main.ts
@@ -17,6 +17,8 @@ const port = parseInt(process.env.PORT || '', 10) || 3000;
 
 import authRouter from './routers/auth';
 import transRouter from './routers/transactions';
+// TODO: Delete import
+import { createSampleData } from './sampleData';
 
 declare module 'express-session' {
   interface SessionData {
@@ -37,6 +39,9 @@ const handle = app.getRequestHandler();
       .then(() => console.log(`connected to database on ${mongoUrl}`)),
     app.prepare().then(() => console.log('next.js server ready')),
   ]);
+
+  // TODO: Delete after tests
+  // await createSampleData(userId);
 
   const server = express();
 

--- a/server/routers/auth.ts
+++ b/server/routers/auth.ts
@@ -2,7 +2,6 @@ import bcrypt from 'bcrypt';
 import { Request, Response, Router } from 'express';
 import { body, validationResult } from 'express-validator';
 
-import isAuthenticated from '../middleware/isAuthenticated';
 import User from '../models/User';
 
 const router = Router();
@@ -58,11 +57,6 @@ router.get('/logout', async (req: Request, res: Response) => {
     req.session.destroy((err) => (err ? reject(err) : resolve())),
   );
   res.redirect('/login');
-});
-
-// TODO: Borrar, es sólo ejemplo de isAuthenticated
-router.get('/hello', isAuthenticated, async (req: Request, res: Response) => {
-  res.send({ user: req.session.user });
 });
 
 export default router;

--- a/server/routers/stats.ts
+++ b/server/routers/stats.ts
@@ -1,0 +1,90 @@
+import { Request, Response, Router } from 'express';
+
+import isAuthenticated from '../middleware/isAuthenticated';
+import Transaction from '../models/Transaction';
+
+const router = Router();
+
+router.get(
+  '/expenses',
+  isAuthenticated,
+  async (req: Request, res: Response) => {
+    const list = await Transaction.aggregate([
+      { $match: { userId: req.session.user, type: 'expense' } },
+      {
+        $group: {
+          _id: '$category',
+          count: { $sum: 1 },
+          amount: { $sum: '$amount' },
+        },
+      },
+    ]);
+    res.send(list);
+  },
+);
+
+router.get('/incomes', isAuthenticated, async (req: Request, res: Response) => {
+  const list = await Transaction.aggregate([
+    { $match: { userId: req.session.user, type: 'income' } },
+    {
+      $group: {
+        _id: '$category',
+        count: { $sum: 1 },
+        amount: { $sum: '$amount' },
+      },
+    },
+  ]);
+  res.send(list);
+});
+
+router.get(
+  '/timeline',
+  isAuthenticated,
+  async (req: Request, res: Response) => {
+    const today = new Date();
+    const projection = {
+      year: { $year: '$date' },
+      month: { $month: '$date' },
+      amount: 1,
+      _id: 0,
+    };
+    const matchDates = {
+      $or: [
+        { year: today.getFullYear() },
+        { year: today.getFullYear() - 1, month: { $gt: today.getMonth() + 1 } },
+      ],
+    };
+    const grouping = { _id: '$month', total: { $sum: '$amount' } };
+    const [incomes, expenses] = await Promise.all([
+      Transaction.aggregate([
+        { $match: { userId: req.session.user, type: 'income' } },
+        { $project: projection },
+        { $match: matchDates },
+        { $group: grouping },
+      ]),
+      Transaction.aggregate([
+        { $match: { userId: req.session.user, type: 'expense' } },
+        { $project: projection },
+        { $match: matchDates },
+        { $group: grouping },
+      ]),
+    ]);
+    console.log(incomes, expenses);
+
+    const dates = Array.from({ length: 12 }, (_, i) => 11 - i)
+      .map(
+        (monthDecrement) =>
+          new Date(today.getFullYear(), today.getMonth() - monthDecrement, 1),
+      )
+      .map((date) => ({
+        date,
+        income: incomes.find((i) => i._id === date.getMonth() + 1)?.total || 0,
+        expense:
+          expenses.find((i) => i._id === date.getMonth() + 1)?.total || 0,
+      }));
+
+    res.send(dates);
+  },
+);
+
+export default router;

--- a/server/sampleData.ts
+++ b/server/sampleData.ts
@@ -1,0 +1,47 @@
+import Transaction from './models/Transaction';
+
+const getRandomCategory = (type: string) => {
+  const categories =
+    type === 'income'
+      ? ['bonus', 'salary', 'sale', 'other']
+      : [
+          'bills',
+          'food',
+          'clothes',
+          'transport',
+          'entertainment',
+          'health',
+          'education',
+          'other',
+        ];
+  return categories[Math.floor(Math.random() * categories.length)];
+};
+
+export const createSampleData = async (userId: string) => {
+  const today = new Date();
+  const dates = Array.from({ length: 12 }, (_, i) => 11 - i).map(
+    (monthDecrement) =>
+      new Date(
+        today.getFullYear(),
+        today.getMonth() - monthDecrement,
+        Math.random() * 28,
+      ),
+  );
+  const transactions = dates
+    .flatMap((date) =>
+      Array.from({ length: Math.floor(10 * Math.random()) }, (_, i) =>
+        Math.random() > 0.5
+          ? { date, type: 'income' }
+          : { date, type: 'expense' },
+      ),
+    )
+    .map((obj, i) => ({
+      ...obj,
+      userId,
+      name: `Transaction ${i}`,
+      category: getRandomCategory(obj.type),
+      amount: Math.random() * 1000,
+    }));
+  await Transaction.insertMany(transactions);
+  console.log(`Generated ${transactions.length} sample transactions`);
+};


### PR DESCRIPTION
Closes #11 

 - Added a way to generate sample transactions with a script. Even the number of transactions is random, but you can influence the total number of transactions by changing the number 10 in server/sampleData.ts, line 32. For it to execute you have to comment out line 45 in server/main.ts, and change the user id for the user id you want to add the transactions to.
 - Added the stats router. After logging in you can visit `/api/stats/expenses`, `/api/stats/income` and `/api/stats/timeline` to query your statistics.